### PR TITLE
Migrate to new proptypes package 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/STORIS/react-material-responsive-grid.git"
   },
   "scripts": {
-	 "build": "npm run build:components && npm run build:copy-files",
+    "build": "npm run build:components && npm run build:copy-files",
     "build:components": "cross-env NODE_ENV=production babel -d ./build ./src",
     "build:copy-files": "babel-node ./scripts/copy-files.js",
     "clean:build": "rimraf ./build",
@@ -54,6 +54,7 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "material-responsive-grid": "^1.1.0",
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
   },

--- a/src/components/Col.jsx
+++ b/src/components/Col.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { getClass, isSizeValid, pushSizeClassNames } from '../shared/utils';
 
 const Col = ({

--- a/src/components/Grid.jsx
+++ b/src/components/Grid.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { getClass } from '../shared/utils';
 
 const Grid = ({

--- a/src/components/Row.jsx
+++ b/src/components/Row.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { getClass, pushSizeClassNames } from '../shared/utils';
 
 const Row = ({


### PR DESCRIPTION
This is to prevent from console warnings when using newer versions of react.